### PR TITLE
feat: migrage ChallengeScoreCard

### DIFF
--- a/lifestylejournal/lifestylejournal.proto
+++ b/lifestylejournal/lifestylejournal.proto
@@ -5,6 +5,7 @@ package taomics.praman.lifestylejournal;
 option go_package = "github.com/taomics/pramanapi/lifestylejournal";
 
 import "praman.proto";
+import "recordlog_type.proto";
 
 /*
         一部英語の表現と日本語の表現が正確でないものがありますが、意図したものです。
@@ -271,9 +272,12 @@ message ChallengeScore {
   string name = 2;
   string url = 3; // 健康課題スコアのヘルプページのURL
   float score = 4;
-  float score_change = 5; // 前回の評価とのスコアの変化
+  string score_text = 13; // スコアテキスト
   Level level = 6;
   repeated LabelGroup label_groups = 7;
+  map<string, string> info = 14;                     // 情報テーブル
+  BehaviorOnTap behavior_on_tap = 15;                // タップ時の挙動
+  taomics.praman.recordlog.LogType related_log = 16; // 関連ログ
 
   // スコアカードをレンダリングするための詳細情報
   // スコアカードは互いに排他的であり、1つのみセットされます。
@@ -285,6 +289,8 @@ message ChallengeScore {
   }
 
   repeated ChallengeScore sub_challenge_scores = 12; // サブスコア
+
+  float score_change = 5 [ deprecated = true ]; // 前回の評価とのスコアの変化
 
   enum Level {
     LEVEL_UNKNOWN = 0;
@@ -312,6 +318,12 @@ message ChallengeScore {
   message Label {
     string name = 1;
     string url = 2;
+  }
+
+  enum BehaviorOnTap {
+    BEHAVIOR_ON_TAP_NONE = 0;
+    OPEN_SUBSCORE = 1;
+    OPEN_RELATED_LOG = 2;
   }
 
   // シンプルスコアカード

--- a/lifestylejournal/lifestylejournal.proto
+++ b/lifestylejournal/lifestylejournal.proto
@@ -272,12 +272,17 @@ message ChallengeScore {
   string name = 2;
   string url = 3; // 健康課題スコアのヘルプページのURL
   float score = 4;
-  string score_text = 13; // スコアテキスト
+  string score_prefix = 20; // スコアの前置き
+  string score_suffix = 21; // スコアの後置き
+  string score_text = 13;   // スコアテキスト
   Level level = 6;
   repeated LabelGroup label_groups = 7;
-  map<string, string> info = 14;                     // 情報テーブル
+  Info info = 14;                                    // 情報テーブル
   BehaviorOnTap behavior_on_tap = 15;                // タップ時の挙動
   taomics.praman.recordlog.LogType related_log = 16; // 関連ログ
+
+  float weekly_score = 18;  // 週間スコア
+  float monthly_score = 19; // 月間スコア
 
   // スコアカードをレンダリングするための詳細情報
   // スコアカードは互いに排他的であり、1つのみセットされます。
@@ -290,7 +295,14 @@ message ChallengeScore {
 
   repeated ChallengeScore sub_challenge_scores = 12; // サブスコア
 
+  /* Deprecated */
   float score_change = 5 [ deprecated = true ]; // 前回の評価とのスコアの変化
+
+  /* Definitions */
+  message Info {
+    string title = 1;
+    map<string, string> values = 2;
+  }
 
   enum Level {
     LEVEL_UNKNOWN = 0;
@@ -310,8 +322,16 @@ message ChallengeScore {
     DeductionFactor = 4;   // 減点要因
   }
 
+  enum LabelGroupIcon {
+    LABEL_GROUP_ICON_UNKNOWN = 0;
+    GOOD = 1; // 良い
+    BAD = 2;  // 悪い
+  }
+
   message LabelGroup {
-    LabelGroupName name = 1;
+    LabelGroupName name = 1 [ deprecated = true ]; // title を使用してください
+    string title = 3;
+    LabelGroupIcon icon = 4;
     repeated Label labels = 2;
   }
 

--- a/recordlog/recordlog.proto
+++ b/recordlog/recordlog.proto
@@ -125,8 +125,8 @@ message MealLog {
 message AlcoholCaffeineLog {
   message Log {
     taomics.praman.Date date = 1;
-    int32 alcohol_quantity = 2;  // 飲酒の摂取量 (合) (1-4)
-    int32 caffeine_quantity = 3; // カフェインの摂取量 (杯)
+    int32 alcohol_quantity = 2;   // 飲酒の摂取量 (合) (1-4)
+    int32 caffeine_quantity = 3;  // カフェインの摂取量 (杯)
     int64 last_caffeine_time = 4; // 最終カフェイン摂取時間
 
     // カフェイン絶時間 (分)

--- a/recordlog/recordlog_type.proto
+++ b/recordlog/recordlog_type.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package taomics.praman.recordlog;
+
+option go_package = "github.com/taomics/pramanapi/recordlog";
+
+enum LogType {
+  LOG_TYPE_UNKNOWN = 0;
+  BodyMetrics = 1;
+  Sleep = 2;
+  Meal = 3;
+  AlcoholCaffeine = 4;
+  Tabacco = 5;
+  Activity = 6;
+  Stress = 7;
+  Stool = 8;
+}
+


### PR DESCRIPTION
健康課題スコアカードの改修に伴いAPIを更新します。

- スコアテキスト機能の追加の対応
- 情報テーブル機能の追加に対応
- タップ時の振る舞いの定義を追加
- score_change の廃止